### PR TITLE
Data migration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,6 @@ public/lib/
 
 # Generated bundle
 public/build/
+
+# Migration
+migrations/.migrate

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ To run the tests, use the following steps:
 
  - Navigate to the project folder
 
-    `$ cd react-docms`
+    `$ cd docue`
 
  - Run the tests through the following command:
 

--- a/migrations/1457249988959-add-roles.js
+++ b/migrations/1457249988959-add-roles.js
@@ -1,0 +1,36 @@
+'use strict';
+
+// load .env
+require('dotenv').load();
+
+const Roles = require('../server/models/roles');
+const titles = Roles.schema.paths.title.enumValues;
+
+exports.up = function(next) {
+
+  let tasks = titles.map((title) => {
+    let query = {title: title};
+    let update = {
+      title: title
+      //accessLevel: 0 // FIXME: Is there a default accessLevel?
+    };
+    return Roles.findOneAndUpdate(query, update, {upsert: true});
+  });
+
+  Promise.all(tasks)
+      .then(()=> { next(); })
+      .catch((error) => {
+        console.error(error);
+        next();
+      });
+};
+
+exports.down = function(next) {
+
+  Roles.remove({ title: { $in: titles}})
+      .then(() => next())
+      .catch((error) => {
+        console.error(error);
+        next();
+      });
+};

--- a/migrations/1457249988959-add-roles.js
+++ b/migrations/1457249988959-add-roles.js
@@ -2,6 +2,7 @@
 
 // load .env
 require('dotenv').load();
+require('../server/config/db');
 
 const Roles = require('../server/models/roles');
 const titles = Roles.schema.paths.title.enumValues;

--- a/migrations/1457249988959-add-roles.js
+++ b/migrations/1457249988959-add-roles.js
@@ -10,10 +10,19 @@ exports.up = function(next) {
 
   let tasks = titles.map((title) => {
     let query = {title: title};
-    let update = {
-      title: title
-      //accessLevel: 0 // FIXME: Is there a default accessLevel?
-    };
+    let update = query;
+    switch (title) {
+      case 'viewer':
+        update['accessLevel'] = 0;
+        break;
+      case 'staff':
+      update['accessLevel'] = 1;
+        break;
+      case 'admin':
+      update['accessLevel'] = 2;
+        break;
+      default:
+    }
     return Roles.findOneAndUpdate(query, update, {upsert: true});
   });
 

--- a/migrations/1457249988959-add-roles.js
+++ b/migrations/1457249988959-add-roles.js
@@ -5,26 +5,16 @@ require('dotenv').load();
 require('../server/config/db');
 
 const Roles = require('../server/models/roles');
-const titles = Roles.schema.paths.title.enumValues;
+const titles = Object.keys(Roles.ACCESS_LEVEL);
 
 exports.up = function(next) {
 
   let tasks = titles.map((title) => {
-    let query = {title: title};
-    let update = query;
-    switch (title) {
-      case 'viewer':
-        update['accessLevel'] = 0;
-        break;
-      case 'staff':
-      update['accessLevel'] = 1;
-        break;
-      case 'admin':
-      update['accessLevel'] = 2;
-        break;
-      default:
-    }
-    return Roles.findOneAndUpdate(query, update, {upsert: true});
+    let update = {
+        title: title,
+        accessLevel: Roles.ACCESS_LEVEL[title]
+    };
+    return Roles.findOneAndUpdate({title: title}, update, {upsert: true});
   });
 
   Promise.all(tasks)

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
   },
   "private": true,
   "scripts": {
+    "prestart": "node node_modules/migrate/bin/migrate",
     "start": "nodemon index.js",
     "test:fend": "./node_modules/.bin/karma start",
     "test:bend": "jasmine",
@@ -39,6 +40,7 @@
     "json-loader": "^0.5.4",
     "jsonwebtoken": "5.5.4",
     "keymirror": "^0.1.1",
+    "migrate": "^0.2.2",
     "moment": "^2.11.2",
     "mongoose": "^4.4.3",
     "morgan": "~1.7.0",

--- a/server/models/roles.js
+++ b/server/models/roles.js
@@ -3,20 +3,31 @@
 
   let mongoose = require('../config/db');
 
+  const ACCESS_LEVEL = {
+    'viewer': 0,
+    'staff': 1,
+    'admin': 2
+  };
+
+  const DEFAULT_ROLE = 'viewer';
+  const DEFAULT_ACCESS_LEVEL = ACCESS_LEVEL[DEFAULT_ROLE];
+
   let RoleSchema = mongoose.Schema({
     title: {
       type: String,
       unique: true,
       required: true,
-      default: 'viewer',
-      enum: ['viewer', 'admin', 'staff']
+      default: DEFAULT_ROLE,
+      enum: Object.keys(ACCESS_LEVEL)
     },
     // The accessLevel will be used to check for permissions
     accessLevel: {
       type: Number,
-      enum: [0, 1, 2]
+      default: DEFAULT_ACCESS_LEVEL,
+      enum: Object.keys(ACCESS_LEVEL).map( (title) => ACCESS_LEVEL[title] )
     }
   });
 
   module.exports = mongoose.model('Role', RoleSchema);
+  module.exports.ACCESS_LEVEL = Object.freeze(ACCESS_LEVEL);
 })();


### PR DESCRIPTION
Use [**node-migrate**](http://github.com/visionmedia/node-migrate) to populate new a database with default data and/or update an existing one in case of schema changes...
So before `npm start` (i.e. `prestart`), we have to run `node node_modules/migrate/bin/migrate`; this resovles #23. 
